### PR TITLE
default disable suspend waking alarms

### DIFF
--- a/services/core/jni/com_android_server_AlarmManagerService.cpp
+++ b/services/core/jni/com_android_server_AlarmManagerService.cpp
@@ -362,6 +362,13 @@ static jlong android_server_AlarmManagerService_init(JNIEnv*, jobject)
         return 0;
     }
 
+    // turn off wake alarms on x86 platforms, unless the user wants it on
+    if(property_get_bool("persist.alarm_manager_service.no_wake_alarms", true)){
+        clockid_t *rw_cast = (clockid_t *) android_alarm_to_clockid;
+        rw_cast[0] = CLOCK_REALTIME;
+        rw_cast[2] = CLOCK_BOOTTIME;
+    }
+
     for (size_t i = 0; i < fds.size(); i++) {
         fds[i] = timerfd_create(android_alarm_to_clockid[i], TFD_NONBLOCK);
         if (fds[i] < 0) {


### PR DESCRIPTION
Disable waking alarms by default on x86, for example RTC_WAKE is used by calendar sync

This will disable framework initiated self waking on motherboards with working alarmtimer wakes

As for other sleeping issues in general, https://github.com/BlissRoms-x86/platform_system_hardware_interfaces/pull/5 is still recommended

An alternative to this would be to disable timerfd alarms in kernel, which would further disable user space wake alarms outside of framework : https://github.com/android-generic/kernel_common/pull/2